### PR TITLE
Fixed getMaxX function

### DIFF
--- a/HorizontalVariableListView/src/it/sephiroth/android/library/widget/HorizontalVariableListView.java
+++ b/HorizontalVariableListView/src/it/sephiroth/android/library/widget/HorizontalVariableListView.java
@@ -1784,7 +1784,7 @@ public class HorizontalVariableListView extends HorizontalListView implements On
 
 	@Override
 	public int getMaxX() {
-		return Integer.MAX_VALUE;
+		return mMaxX;
 	}
 
 	public void setDragTolerance( int value ) {


### PR DESCRIPTION
Summary: getMaxX function should always return mMaxX value.
So far function returns always Integer.MAX_VALUE and this value
was used by onFling method.
