### PR TITLE
Support renamed packages.

### DIFF
--- a/demo/AndroidManifest.xml
+++ b/demo/AndroidManifest.xml
@@ -11,7 +11,8 @@
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
         android:theme="@style/AppTheme"
-        android:hardwareAccelerated="true">
+        android:hardwareAccelerated="true"
+        android:name=".DemoApplication">
         <activity
             android:name=".MainActivity"
             android:label="@string/app_name"

--- a/demo/src/it/sephiroth/android/sample/horizontalvariablelistviewdemo/DemoApplication.java
+++ b/demo/src/it/sephiroth/android/sample/horizontalvariablelistviewdemo/DemoApplication.java
@@ -1,0 +1,10 @@
+package it.sephiroth.android.sample.horizontalvariablelistviewdemo;
+
+import android.app.Application;
+
+public class DemoApplication extends Application {
+    public DemoApplication() {
+        // Setup your resource package name before the HListView is inflated if you rename your package with aapt's --rename-manifest-package option
+//        ResourcePackageName.setResourcePackageName("it.sephiroth.android.sample.horizontalvariablelistviewdemo");
+    }
+}

--- a/library/src/it/sephiroth/android/library/widget/EdgeEffect.java
+++ b/library/src/it/sephiroth/android/library/widget/EdgeEffect.java
@@ -137,14 +137,15 @@ public class EdgeEffect {
      */
     public EdgeEffect(Context context, int direction ) {
         final Resources res = context.getResources();
-        int resId = res.getIdentifier( "hlv_overscroll_edge", "drawable", context.getPackageName() );
+        String resourcePackageName = ResourcePackageName.getResourcePackageName(context);
+        int resId = res.getIdentifier( "hlv_overscroll_edge", "drawable", resourcePackageName );
         if( resId > 0 ) {
         	mEdge = res.getDrawable(resId);
         } else {
         	throw new IllegalStateException( "Cannot find resource 'hlv_overscroll_edge'" );
         }
         
-        resId = res.getIdentifier( "hlv_overscroll_glow", "drawable", context.getPackageName() );
+        resId = res.getIdentifier( "hlv_overscroll_glow", "drawable", resourcePackageName );
         if( resId > 0 ) {
         	mGlow = res.getDrawable(resId);
         } else {

--- a/library/src/it/sephiroth/android/library/widget/ResourcePackageName.java
+++ b/library/src/it/sephiroth/android/library/widget/ResourcePackageName.java
@@ -1,0 +1,26 @@
+package it.sephiroth.android.library.widget;
+
+import android.content.Context;
+
+public final class ResourcePackageName {
+    private static String resourcePackageName;
+
+    /**
+     * Not intended for instantiation
+     */
+    private ResourcePackageName() {
+    }
+
+    public static String getResourcePackageName(Context context) {
+        if ( resourcePackageName == null ) {
+            String contextPackageName = context.getPackageName();
+            return contextPackageName;
+        } else {
+            return resourcePackageName;
+        }
+    }
+
+    public static void setResourcePackageName(String resourcePackageName) {
+        ResourcePackageName.resourcePackageName = resourcePackageName;
+    }
+}


### PR DESCRIPTION
When aapt's --rename-manifest-package option is used, the app's resources are not placed under the same package as Context.getPackageName(). I haven't figured out a way to discover the available packages that could contain resources so that we could perform a search. Instead, I provided a global variable consumers can use to tell us their resource package name.

This fixes stack traces like this:

```
java.lang.IllegalStateException: Cannot find resource 'hlv_overscroll_edge'
    at it.sephiroth.android.library.widget.EdgeEffect.<init>(EdgeEffect.java:144)
    at it.sephiroth.android.library.widget.AbsHListView.setOverScrollMode(AbsHListView.java:697)
    at android.view.View.<init>(View.java:3237)
    at android.view.View.<init>(View.java:3295)
    at android.view.ViewGroup.<init>(ViewGroup.java:427)
    at it.sephiroth.android.library.widget.AdapterView.<init>(AdapterView.java:224)
    at it.sephiroth.android.library.widget.AbsHListView.<init>(AbsHListView.java:630)
    at it.sephiroth.android.library.widget.HListView.<init>(HListView.java:151)
    at it.sephiroth.android.library.widget.HListView.<init>(HListView.java:147)
    at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
    at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:57)
    at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
    at java.lang.reflect.Constructor.newInstance(Constructor.java:532)
    at com.android.ide.eclipse.adt.internal.editors.layout.ProjectCallback.instantiateClass(ProjectCallback.java:422)
    at com.android.ide.eclipse.adt.internal.editors.layout.ProjectCallback.loadView(ProjectCallback.java:179)
    at android.view.BridgeInflater.loadCustomView(BridgeInflater.java:207)
    at android.view.BridgeInflater.createViewFromTag(BridgeInflater.java:135)
    at android.view.LayoutInflater.rInflate_Original(LayoutInflater.java:746)
    at android.view.LayoutInflater_Delegate.rInflate(LayoutInflater_Delegate.java:64)
    at android.view.LayoutInflater.rInflate(LayoutInflater.java:718)
    at android.view.LayoutInflater.inflate(LayoutInflater.java:489)
    at android.view.LayoutInflater.inflate(LayoutInflater.java:372)
    at com.android.layoutlib.bridge.impl.RenderSessionImpl.inflate(RenderSessionImpl.java:383)
    at com.android.layoutlib.bridge.Bridge.createSession(Bridge.java:332)
    at com.android.ide.common.rendering.LayoutLibrary.createSession(LayoutLibrary.java:325)
    at com.android.ide.eclipse.adt.internal.editors.layout.gle2.RenderService.createRenderSession(RenderService.java:440)
    at com.android.ide.eclipse.adt.internal.editors.layout.gle2.GraphicalEditorPart.renderWithBridge(GraphicalEditorPart.java:1545)
    at com.android.ide.eclipse.adt.internal.editors.layout.gle2.GraphicalEditorPart.recomputeLayout(GraphicalEditorPart.java:1302)
    at com.android.ide.eclipse.adt.internal.editors.layout.gle2.GraphicalEditorPart$ReloadListener.reloadLayoutSwt(GraphicalEditorPart.java:1777)
    at com.android.ide.eclipse.adt.internal.editors.layout.gle2.GraphicalEditorPart$ReloadListener.access$0(GraphicalEditorPart.java:1715)
    at com.android.ide.eclipse.adt.internal.editors.layout.gle2.GraphicalEditorPart$ReloadListener$1.run(GraphicalEditorPart.java:1709)
    at org.eclipse.swt.widgets.RunnableLock.run(RunnableLock.java:35)
    at org.eclipse.swt.widgets.Synchronizer.runAsyncMessages(Synchronizer.java:135)
    at org.eclipse.swt.widgets.Display.runAsyncMessages(Display.java:3537)
    at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3189)
    at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$9.run(PartRenderingEngine.java:1053)
    at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:332)
    at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:942)
    at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:86)
    at org.eclipse.ui.internal.Workbench$5.run(Workbench.java:588)
    at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:332)
    at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:543)
    at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:149)
    at org.eclipse.ui.internal.ide.application.IDEApplication.start(IDEApplication.java:124)
    at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:196)
    at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:110)
    at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:79)
    at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:353)
    at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:180)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:616)
    at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:629)
    at org.eclipse.equinox.launcher.Main.basicRun(Main.java:584)
    at org.eclipse.equinox.launcher.Main.run(Main.java:1438)
```
