### PR TITLE
Updates build tools version and removes targetSdkVersion

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -5,18 +5,17 @@ group 'it.sephiroth.android.library.horizontallistview'
 version '1.2.1'
 
 dependencies {
-    compile 'com.android.support:support-v4:19.0.1+'
+    compile 'com.android.support:support-v4:19.0.3+'
 }
 
 android {
     compileSdkVersion 19
-    buildToolsVersion "19.0.1"
+    buildToolsVersion "19.0.3"
 
     defaultConfig {
         versionCode 1
         versionName version
         minSdkVersion 9
-        targetSdkVersion 19
     }
 
     sourceSets {


### PR DESCRIPTION
Since I can't use targetSdkVersion=19 on my project, this caused a build error.
Removing targetSdkVersion so you leave for the actual including project to determine which sdk version to use.
Also updated the build tools version to 19.0.3
