### PR TITLE
fix focus directions use around handleVerticalFocusWithinListItem

### DIFF
--- a/library/src/main/java/it/sephiroth/android/library/widget/AbsHListView.java
+++ b/library/src/main/java/it/sephiroth/android/library/widget/AbsHListView.java
@@ -5151,9 +5151,6 @@ public abstract class AbsHListView extends AdapterView<ListAdapter> implements V
 	 * @return the distance between the rectangles
 	 */
 	public static int getDistance( Rect source, Rect dest, int direction ) {
-
-		// TODO: implement this
-
 		int sX, sY; // source x, y
 		int dX, dY; // dest x, y
 		switch ( direction ) {

--- a/library/src/main/java/it/sephiroth/android/library/widget/HListView.java
+++ b/library/src/main/java/it/sephiroth/android/library/widget/HListView.java
@@ -2227,13 +2227,13 @@ public class HListView extends AbsHListView {
 
 				case KeyEvent.KEYCODE_DPAD_UP:
 					if ( event.hasNoModifiers() ) {
-						handled = handleHorizontalFocusWithinListItem( View.FOCUS_UP );
+						handled = handleVerticalFocusWithinListItem( View.FOCUS_UP );
 					}
 					break;
 
 				case KeyEvent.KEYCODE_DPAD_DOWN:
 					if ( event.hasNoModifiers() ) {
-						handled = handleHorizontalFocusWithinListItem( View.FOCUS_DOWN );
+						handled = handleVerticalFocusWithinListItem( View.FOCUS_DOWN );
 					}
 					break;
 
@@ -2252,38 +2252,38 @@ public class HListView extends AbsHListView {
 				case KeyEvent.KEYCODE_SPACE:
 
 					if ( event.hasNoModifiers() ) {
-						handled = resurrectSelectionIfNeeded() || pageScroll( FOCUS_DOWN );
+						handled = resurrectSelectionIfNeeded() || pageScroll( FOCUS_RIGHT );
 					} else if ( event.hasModifiers( KeyEvent.META_SHIFT_ON ) ) {
-						handled = resurrectSelectionIfNeeded() || pageScroll( FOCUS_UP );
+						handled = resurrectSelectionIfNeeded() || pageScroll( FOCUS_LEFT );
 					}
 					handled = true;
 					break;
 
 				case KeyEvent.KEYCODE_PAGE_UP:
 					if ( event.hasNoModifiers() ) {
-						handled = resurrectSelectionIfNeeded() || pageScroll( FOCUS_UP );
+						handled = resurrectSelectionIfNeeded() || pageScroll( FOCUS_LEFT );
 					} else if ( event.hasModifiers( KeyEvent.META_ALT_ON ) ) {
-						handled = resurrectSelectionIfNeeded() || fullScroll( FOCUS_UP );
+						handled = resurrectSelectionIfNeeded() || fullScroll( FOCUS_LEFT );
 					}
 					break;
 
 				case KeyEvent.KEYCODE_PAGE_DOWN:
 					if ( event.hasNoModifiers() ) {
-						handled = resurrectSelectionIfNeeded() || pageScroll( FOCUS_DOWN );
+						handled = resurrectSelectionIfNeeded() || pageScroll( FOCUS_RIGHT );
 					} else if ( event.hasModifiers( KeyEvent.META_ALT_ON ) ) {
-						handled = resurrectSelectionIfNeeded() || fullScroll( FOCUS_DOWN );
+						handled = resurrectSelectionIfNeeded() || fullScroll( FOCUS_RIGHT );
 					}
 					break;
 
 				case KeyEvent.KEYCODE_MOVE_HOME:
 					if ( event.hasNoModifiers() ) {
-						handled = resurrectSelectionIfNeeded() || fullScroll( FOCUS_UP );
+						handled = resurrectSelectionIfNeeded() || fullScroll( FOCUS_LEFT );
 					}
 					break;
 
 				case KeyEvent.KEYCODE_MOVE_END:
 					if ( event.hasNoModifiers() ) {
-						handled = resurrectSelectionIfNeeded() || fullScroll( FOCUS_DOWN );
+						handled = resurrectSelectionIfNeeded() || fullScroll( FOCUS_RIGHT );
 					}
 					break;
 
@@ -2315,15 +2315,16 @@ public class HListView extends AbsHListView {
 	 * Scrolls left or right by the number of items currently present on screen.
 	 * 
 	 * @param direction
-	 *           either {@link View#FOCUS_UP} or {@link View#FOCUS_DOWN}
+	 *           either {@link View#FOCUS_LEFT} or {@link View#FOCUS_RIGHT}
 	 * @return whether selection was moved
 	 */
 	boolean pageScroll( int direction ) {
 		int nextPage = -1;
 		boolean down = false;
 
-		if ( direction == FOCUS_UP ) { nextPage = Math.max( 0, mSelectedPosition - getChildCount() - 1 );
-		} else if ( direction == FOCUS_DOWN ) {
+		if ( direction == FOCUS_LEFT ) {
+            nextPage = Math.max( 0, mSelectedPosition - getChildCount() - 1 );
+		} else if ( direction == FOCUS_RIGHT ) {
 			nextPage = Math.min( mItemCount - 1, mSelectedPosition + getChildCount() - 1 );
 			down = true;
 		}
@@ -2360,13 +2361,13 @@ public class HListView extends AbsHListView {
 	 * currently selected item.)
 	 * 
 	 * @param direction
-	 *           either {@link View#FOCUS_UP} or {@link View#FOCUS_DOWN}
+	 *           either {@link View#FOCUS_LEFT} or {@link View#FOCUS_RIGHT}
 	 * 
 	 * @return whether selection was moved
 	 */
 	boolean fullScroll( int direction ) {
 		boolean moved = false;
-		if ( direction == FOCUS_UP ) {
+		if ( direction == FOCUS_LEFT ) {
 			if ( mSelectedPosition != 0 ) {
 				int position = lookForSelectablePosition( 0, true );
 				if ( position >= 0 ) {
@@ -2376,7 +2377,7 @@ public class HListView extends AbsHListView {
 				}
 				moved = true;
 			}
-		} else if ( direction == FOCUS_DOWN ) {
+		} else if ( direction == FOCUS_RIGHT ) {
 			if ( mSelectedPosition < mItemCount - 1 ) {
 				int position = lookForSelectablePosition( mItemCount - 1, true );
 				if ( position >= 0 ) {
@@ -2397,15 +2398,14 @@ public class HListView extends AbsHListView {
 	}
 
 	/**
-	 * To avoid horizontal focus searches changing the selected item, we manually focus search within the selected item (as
+	 * To avoid vertical focus searches changing the selected item, we manually focus search within the selected item (as
 	 * applicable), and prevent focus from jumping to something within another item.
 	 * 
 	 * @param direction
-	 *           one of {View.FOCUS_LEFT, View.FOCUS_RIGHT}
+	 *           one of {View.FOCUS_UP, View.FOCUS_DOWN}
 	 * @return Whether this consumes the key event.
 	 */
-	private boolean handleHorizontalFocusWithinListItem( int direction ) {
-		// TODO: implement this
+	private boolean handleVerticalFocusWithinListItem( int direction ) {
 		if ( direction != View.FOCUS_UP && direction != View.FOCUS_DOWN ) {
 			throw new IllegalArgumentException( "direction must be one of"
 					+ " {View.FOCUS_UP, View.FOCUS_DOWN}" );
@@ -2447,7 +2447,7 @@ public class HListView extends AbsHListView {
 	 * Scrolls to the next or previous item if possible.
 	 * 
 	 * @param direction
-	 *           either {@link View#FOCUS_UP} or {@link View#FOCUS_DOWN}
+	 *           either {@link View#FOCUS_LEFT} or {@link View#FOCUS_RIGHT}
 	 * 
 	 * @return whether selection was moved
 	 */
@@ -2469,7 +2469,7 @@ public class HListView extends AbsHListView {
 	 * etc.
 	 * 
 	 * @param direction
-	 *           Either {@link android.view.View#FOCUS_UP} or {@link android.view.View#FOCUS_DOWN}.
+	 *           Either {@link android.view.View#FOCUS_LEFT} or {@link android.view.View#FOCUS_RIGHT}.
 	 * @return Whether any scrolling, selection or focus change occured.
 	 */
 	private boolean arrowScrollImpl( int direction ) {
@@ -2510,7 +2510,7 @@ public class HListView extends AbsHListView {
 		}
 
 		if ( amountToScroll > 0 ) {
-			scrollListItemsBy( ( direction == View.FOCUS_UP ) ? amountToScroll : -amountToScroll );
+			scrollListItemsBy( ( direction == View.FOCUS_LEFT ) ? amountToScroll : -amountToScroll );
 			needToRedraw = true;
 		}
 
@@ -2556,7 +2556,7 @@ public class HListView extends AbsHListView {
 	 *           The currently selected view (before changing selection). should be <code>null</code> if there was no previous
 	 *           selection.
 	 * @param direction
-	 *           Either {@link android.view.View#FOCUS_UP} or {@link android.view.View#FOCUS_DOWN}.
+	 *           Either {@link android.view.View#FOCUS_LEFT} or {@link android.view.View#FOCUS_RIGHT}.
 	 * @param newSelectedPosition
 	 *           The position of the next selection.
 	 * @param newFocusAssigned
@@ -2580,7 +2580,7 @@ public class HListView extends AbsHListView {
 		final int selectedIndex = mSelectedPosition - mFirstPosition;
 		final int nextSelectedIndex = newSelectedPosition - mFirstPosition;
 		
-		if ( direction == View.FOCUS_UP ) {
+		if ( direction == View.FOCUS_LEFT ) {
 			leftViewIndex = nextSelectedIndex;
 			rightViewIndex = selectedIndex;
 			leftView = getChildAt( leftViewIndex );
@@ -2689,7 +2689,7 @@ public class HListView extends AbsHListView {
 	 * applicable. The amount is capped at {@link #getMaxScrollAmount()} .
 	 * 
 	 * @param direction
-	 *           either {@link android.view.View#FOCUS_UP} or {@link android.view.View#FOCUS_DOWN}.
+	 *           either {@link android.view.View#FOCUS_LEFT} or {@link android.view.View#FOCUS_RIGHT}.
 	 * @param nextSelectedPosition
 	 *           The position of the next selection, or {@link #INVALID_POSITION} if there is no next selectable position
 	 * @return The amount to scroll. Note: this is always positive! Direction needs to be taken into account when actually scrolling.
@@ -2700,7 +2700,7 @@ public class HListView extends AbsHListView {
 
 		final int numChildren = getChildCount();
 
-		if ( direction == View.FOCUS_DOWN ) {
+		if ( direction == View.FOCUS_RIGHT ) {
 			int indexToMakeVisible = numChildren - 1;
 			if ( nextSelectedPosition != INVALID_POSITION ) {
 				indexToMakeVisible = nextSelectedPosition - mFirstPosition;
@@ -2793,14 +2793,14 @@ public class HListView extends AbsHListView {
 
 	/**
 	 * @param direction
-	 *           either {@link android.view.View#FOCUS_UP} or {@link android.view.View#FOCUS_DOWN}.
+	 *           either {@link android.view.View#FOCUS_LEFT} or {@link android.view.View#FOCUS_RIGHT}.
 	 * @return The position of the next selectable position of the views that are currently visible, taking into account the fact
 	 *         that there might be no selection. Returns {@link #INVALID_POSITION} if there is no selectable view on screen in the
 	 *         given direction.
 	 */
 	private int lookForSelectablePositionOnScreen( int direction ) {
 		final int firstPosition = mFirstPosition;
-		if ( direction == View.FOCUS_DOWN ) {
+		if ( direction == View.FOCUS_RIGHT ) {
 			int startPos = ( mSelectedPosition != INVALID_POSITION ) ?
 					mSelectedPosition + 1 :
 					firstPosition;
@@ -2847,7 +2847,7 @@ public class HListView extends AbsHListView {
 	 * an {@link ArrowScrollFocusResult}, otherwise, return null.
 	 * 
 	 * @param direction
-	 *           either {@link android.view.View#FOCUS_UP} or {@link android.view.View#FOCUS_DOWN}.
+	 *           either {@link android.view.View#FOCUS_LEFT} or {@link android.view.View#FOCUS_RIGHT}.
 	 * @return The result if focus has changed, or <code>null</code>.
 	 */
 	private ArrowScrollFocusResult arrowScrollFocused( final int direction ) {
@@ -2857,7 +2857,7 @@ public class HListView extends AbsHListView {
 			View oldFocus = selectedView.findFocus();
 			newFocus = FocusFinder.getInstance().findNextFocus( this, oldFocus, direction );
 		} else {
-			if ( direction == View.FOCUS_DOWN ) {
+			if ( direction == View.FOCUS_RIGHT ) {
 				final boolean leftFadingEdgeShowing = ( mFirstPosition > 0 );
 				final int listLeft = mListPadding.left +
 						( leftFadingEdgeShowing ? getArrowScrollPreviewLength() : 0 );
@@ -2888,8 +2888,8 @@ public class HListView extends AbsHListView {
 			if ( mSelectedPosition != INVALID_POSITION && positionOfNewFocus != mSelectedPosition ) {
 				final int selectablePosition = lookForSelectablePositionOnScreen( direction );
 				if ( selectablePosition != INVALID_POSITION &&
-						( ( direction == View.FOCUS_DOWN && selectablePosition < positionOfNewFocus ) ||
-						( direction == View.FOCUS_UP && selectablePosition > positionOfNewFocus ) ) ) {
+						( ( direction == View.FOCUS_RIGHT && selectablePosition < positionOfNewFocus ) ||
+						( direction == View.FOCUS_LEFT && selectablePosition > positionOfNewFocus ) ) ) {
 					return null;
 				}
 			}
@@ -2948,7 +2948,7 @@ public class HListView extends AbsHListView {
 	 * Determine how much we need to scroll in order to get newFocus in view.
 	 * 
 	 * @param direction
-	 *           either {@link android.view.View#FOCUS_UP} or {@link android.view.View#FOCUS_DOWN}.
+	 *           either {@link android.view.View#FOCUS_LEFT} or {@link android.view.View#FOCUS_RIGHT}.
 	 * @param newFocus
 	 *           The view that would take focus.
 	 * @param positionOfNewFocus
@@ -2959,7 +2959,7 @@ public class HListView extends AbsHListView {
 		int amountToScroll = 0;
 		newFocus.getDrawingRect( mTempRect );
 		offsetDescendantRectToMyCoords( newFocus, mTempRect );
-		if ( direction == View.FOCUS_UP ) {
+		if ( direction == View.FOCUS_LEFT ) {
 			if ( mTempRect.left < mListPadding.left ) {
 				amountToScroll = mListPadding.left - mTempRect.left;
 				if ( positionOfNewFocus > 0 ) {


### PR DESCRIPTION
Due to the TODOs left over, I get the impression the focus directions weren't finished. This is the finished conversion from Android ListView source. It is a subtle bugfix for focus control internal to list items and keeping left and right semantically correct.
